### PR TITLE
Changed Unroll syntax for Spock 0.6-SNAPSHOT

### DIFF
--- a/EqualsHashcodeTestGrailsPlugin.groovy
+++ b/EqualsHashcodeTestGrailsPlugin.groovy
@@ -1,7 +1,7 @@
 class EqualsHashcodeTestGrailsPlugin {
-    def version = '0.2.0'
-    def grailsVersion = '1.3 > *'
-    def dependsOn = [spock: '0.5-groovy-1.7']
+    def version = '0.2.0-spock-0.6-SNAPSHOT'
+    def grailsVersion = '2.0.0 > *'
+    def dependsOn = [spock: '0.6-SNAPSHOT']
 
     def author = 'Marcin Gryszko'
     def authorEmail = 'marcin@gryszko.net'

--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,5 @@
 #Grails Metadata file
 #Wed May 11 23:56:23 CEST 2011
-app.grails.version=1.3.7
+app.grails.version=2.0.0
 app.name=equals-hashcode-test
-plugins.spock=0.5-groovy-1.7
+plugins.spock=0.6-SNAPSHOT

--- a/src/groovy/es/osoco/grails/plugins/EqualsHashCodeSpec.groovy
+++ b/src/groovy/es/osoco/grails/plugins/EqualsHashCodeSpec.groovy
@@ -81,7 +81,7 @@ class EqualsHashCodeSpec extends UnitSpec {
         !domainObject.equals(new Object())
     }
 
-    @Unroll("equals and hashCode use #property")
+    @Unroll({"equals and hashCode use $property"})
     def "equals and hashCode use some properties"() {
         setup:
         def domainObject = createDomainObjectToCompare()
@@ -96,7 +96,7 @@ class EqualsHashCodeSpec extends UnitSpec {
         property << modifiedPropertiesIncludedInEqualsAndHashCode()
     }
 
-    @Unroll("equals and hashCode ignore #property")
+    @Unroll({"equals and hashCode ignore $property"})
     def "equals and hashCode ignore some properties"() {
         setup:
         def domainObject = createDomainObjectToCompare()


### PR DESCRIPTION
Changes required to use the plugin in Grails-2.0.0 or later. Particularly, current spock 0.6-SNAPSHOT version has changed the Unroll syntax to use a closure as argument.

It seems it is planned another syntax change previous to the 0.6 release as you can see in this thread: http://spock-framework.3207229.n2.nabble.com/Problem-with-Unroll-with-groovy-1-8-td6317496.html

However the new syntax hasn't been implemented yet.

I suggest a new branch spock-0.6-groovy-1.8 and add these changes to a 0.2.0-spock-0.6-SNAPSHOT version.
