### PR TITLE
Fixed Unroll syntax for Spock-0.6 version

### DIFF
--- a/src/groovy/es/osoco/grails/plugins/EqualsHashCodeSpec.groovy
+++ b/src/groovy/es/osoco/grails/plugins/EqualsHashCodeSpec.groovy
@@ -81,7 +81,7 @@ class EqualsHashCodeSpec extends UnitSpec {
         !domainObject.equals(new Object())
     }
 
-    @Unroll({"equals and hashCode use $property"})
+    @Unroll("equals and hashCode use #property")
     def "equals and hashCode use some properties"() {
         setup:
         def domainObject = createDomainObjectToCompare()
@@ -96,7 +96,7 @@ class EqualsHashCodeSpec extends UnitSpec {
         property << modifiedPropertiesIncludedInEqualsAndHashCode()
     }
 
-    @Unroll({"equals and hashCode ignore $property"})
+    @Unroll("equals and hashCode ignore #property")
     def "equals and hashCode ignore some properties"() {
         setup:
         def domainObject = createDomainObjectToCompare()


### PR DESCRIPTION
The Unroll annotation syntax has changed again in Spock-0.6 version as you can see in the Javadoc:
https://github.com/spockframework/spock/blob/groovy-1.7/spock-core/src/main/java/spock/lang/Unroll.java
